### PR TITLE
Correct Additional Layer Information size rounding.

### DIFF
--- a/src/Psd/PsdParseLayerMaskSection.cpp
+++ b/src/Psd/PsdParseLayerMaskSection.cpp
@@ -696,9 +696,9 @@ namespace
 
 					const uint32_t key = fileUtil::ReadFromFileBE<uint32_t>(reader);
 
-					// length needs to be rounded to a multiple of 4
+					// length needs to be rounded to an even number
 					uint32_t length = fileUtil::ReadFromFileBE<uint32_t>(reader);
-					length = bitUtil::RoundUpToMultiple(length, 4u);
+					length = bitUtil::RoundUpToMultiple(length, 2u);
 
 					// read "Section divider setting" to identify whether a layer is a group, or a section divider
 					if (key == util::Key<'l', 's', 'c', 't'>::VALUE)


### PR DESCRIPTION
According to the spec published by Adobe: "Length data below, rounded up to an even byte count."

PSB support (which isn't currently implemented) would necessitate adjusting this rounding up to 8 bytes depending on the key read.

This should correct #7, or at least it did for us.