### PR TITLE
Add not vectorized implementations

### DIFF
--- a/src/Psd/PsdInterleave.cpp
+++ b/src/Psd/PsdInterleave.cpp
@@ -16,8 +16,6 @@
 
 #if PSD_USE_SSE
 	#include <emmintrin.h>
-#else
-	#include <tuple>
 #endif
 
 
@@ -242,10 +240,9 @@ namespace imageUtil
 	// ---------------------------------------------------------------------------------------------------------------------
 	// ---------------------------------------------------------------------------------------------------------------------
 	template <typename T>
-	void InterleaveRGB(const T* PSD_RESTRICT srcR, const T* PSD_RESTRICT srcG, const T* PSD_RESTRICT srcB, T alpha, T* PSD_RESTRICT dest, unsigned int width, unsigned int height, unsigned int blockSize)
+	void InterleaveRGB(const T* PSD_RESTRICT srcR, const T* PSD_RESTRICT srcG, const T* PSD_RESTRICT srcB, T alpha, T* PSD_RESTRICT dest, unsigned int width, unsigned int height, unsigned int /* blockSize */)
 	{
 		// copy pixels
-		std::ignore = blockSize;
 		const unsigned int count = width * height;
 		CopyRemainingPixels(srcR, srcG, srcB, alpha, dest, count);
 	}
@@ -254,10 +251,9 @@ namespace imageUtil
 	// ---------------------------------------------------------------------------------------------------------------------
 	// ---------------------------------------------------------------------------------------------------------------------
 	template <typename T>
-	void InterleaveRGBA(const T* PSD_RESTRICT srcR, const T* PSD_RESTRICT srcG, const T* PSD_RESTRICT srcB, const T* PSD_RESTRICT srcA, T* PSD_RESTRICT dest, unsigned int width, unsigned int height, unsigned int blockSize)
+	void InterleaveRGBA(const T* PSD_RESTRICT srcR, const T* PSD_RESTRICT srcG, const T* PSD_RESTRICT srcB, const T* PSD_RESTRICT srcA, T* PSD_RESTRICT dest, unsigned int width, unsigned int height, unsigned int /* blockSize */)
 	{
 		// copy pixels
-		std::ignore = blockSize;
 		const unsigned int count = width * height;
 		CopyRemainingPixels(srcR, srcG, srcB, srcA, dest, count);
 	}

--- a/src/Psd/PsdInterleave.cpp
+++ b/src/Psd/PsdInterleave.cpp
@@ -6,24 +6,24 @@
 
 #include "PsdUnionCast.h"
 
-#if !defined(USE_SSE)
-#if defined(_M_IX86) || defined(_M_X64)
-#define USE_SSE 1
-#else
-#define USE_SSE 0
-#endif
+#if !defined(PSD_USE_SSE)
+	#if defined(_M_IX86) || defined(_M_X64)
+		#define PSD_USE_SSE 1
+	#else
+		#define PSD_USE_SSE 0
+	#endif
 #endif
 
-#if USE_SSE
-#include <emmintrin.h>
+#if PSD_USE_SSE
+	#include <emmintrin.h>
 #else
-#include <tuple>
+	#include <tuple>
 #endif
 
 
 PSD_NAMESPACE_BEGIN
 
-#if USE_SSE
+#if PSD_USE_SSE
 // splats a single 8-bit, 16-bit or 32-bit value into a SSE2 register
 namespace
 {
@@ -90,7 +90,7 @@ namespace
 
 namespace imageUtil
 {
-#if USE_SSE
+#if PSD_USE_SSE
 	// ---------------------------------------------------------------------------------------------------------------------
 	// ---------------------------------------------------------------------------------------------------------------------
 	template <typename T>
@@ -215,7 +215,7 @@ namespace imageUtil
 	}
 
 
-#if USE_SSE
+#if PSD_USE_SSE
 	// ---------------------------------------------------------------------------------------------------------------------
 	// ---------------------------------------------------------------------------------------------------------------------
 	template <typename T>


### PR DESCRIPTION
Add not vectorized implementations (without SSE) of the **InterleaveRGB** and **InterleaveRGBA** utility functions to allow building the library for architectures without SSE support.