### PR TITLE
Defined PSD_STATIC_ASSERT macros

### DIFF
--- a/src/Psd/PsdCompilerMacros.h
+++ b/src/Psd/PsdCompilerMacros.h
@@ -144,3 +144,11 @@
 	#define static_assert(condition, message)			typedef char PSD_JOIN(static_assert_impl_, __LINE__)[(condition) ? 1 : -1]
 	#define nullptr										NULL
 #endif
+
+#define PSD_STATIC_ASSERT_MSG(condition, message)		static_assert((condition), message)
+
+#if __cpp_static_assert >= 201411
+	#define PSD_STATIC_ASSERT(condition)				static_assert((condition))
+#else
+	#define PSD_STATIC_ASSERT(condition)				static_assert((condition), "")
+#endif

--- a/src/Psd/PsdCompilerMacros.h
+++ b/src/Psd/PsdCompilerMacros.h
@@ -145,10 +145,8 @@
 	#define nullptr										NULL
 #endif
 
+/// \def PSD_STATIC_ASSERT_MSG
 #define PSD_STATIC_ASSERT_MSG(condition, message)		static_assert((condition), message)
 
-#if __cpp_static_assert >= 201411
-	#define PSD_STATIC_ASSERT(condition)				static_assert((condition))
-#else
-	#define PSD_STATIC_ASSERT(condition)				static_assert((condition), "")
-#endif
+/// \def PSD_STATIC_ASSERT
+#define PSD_STATIC_ASSERT(condition)					static_assert((condition), "")

--- a/src/Samples/PsdSamples.cpp
+++ b/src/Samples/PsdSamples.cpp
@@ -366,7 +366,7 @@ int SampleReadPsd(void)
 			{
 				#ifdef _WIN32
 				//In Windows wchar_t is utf16
-				static_assert(sizeof(wchar_t) == sizeof(uint16_t));
+				PSD_STATIC_ASSERT(sizeof(wchar_t) == sizeof(uint16_t));
 				layerName << reinterpret_cast<wchar_t*>(layer->utf16Name);
 				#else
 				//In Linux, wchar_t is utf32
@@ -387,7 +387,7 @@ int SampleReadPsd(void)
 				{
 					return ((high << 10) + low - 0x35fdc00);
 				};
-				static_assert(sizeof(wchar_t) == sizeof(uint32_t));
+				PSD_STATIC_ASSERT(sizeof(wchar_t) == sizeof(uint32_t));
 
 				//Begin convert
 				size_t u16len = 0;


### PR DESCRIPTION
Defined PSD_STATIC_ASSERT macros
  message can be omitted under C++17