### PR TITLE
Allow reading pass-through property of layers

### DIFF
--- a/src/Psd/PsdLayer.h
+++ b/src/Psd/PsdLayer.h
@@ -41,6 +41,7 @@ struct Layer
 
 	uint32_t type;						///< The layer's type. Can be any of \ref layerType::Enum.
 	bool isVisible;						///< The layer's visibility.
+	bool isPassThrough;					///< If the layer is a pass-through group.
 };
 
 PSD_NAMESPACE_END

--- a/src/Psd/PsdParseLayerMaskSection.cpp
+++ b/src/Psd/PsdParseLayerMaskSection.cpp
@@ -528,6 +528,7 @@ namespace
 				layer->layerMask = nullptr;
 				layer->vectorMask = nullptr;
 				layer->type = layerType::ANY;
+				layer->isPassThrough = false;
 
 				layer->top = fileUtil::ReadFromFileBE<int32_t>(reader);
 				layer->left = fileUtil::ReadFromFileBE<int32_t>(reader);
@@ -705,8 +706,22 @@ namespace
 					{
 						layer->type = fileUtil::ReadFromFileBE<uint32_t>(reader);
 
-						// skip the rest of the data
-						reader.Skip(length - 4u);
+						// there may be another blend mode here to tell us if the group is pass-through
+						if(length >= 12u)
+						{
+							const uint32_t lsctKey = fileUtil::ReadFromFileBE<uint32_t>(reader);
+							const uint32_t modeKey = fileUtil::ReadFromFileBE<uint32_t>(reader);
+							if (lsctKey == util::Key<'8', 'B', 'I', 'M'>::VALUE && modeKey == util::Key<'p', 'a', 's', 's'>::VALUE)
+							{
+								layer->isPassThrough = true;
+							}
+							reader.Skip(length - 12u);
+						}
+						else
+						{
+							// skip the rest of the data
+							reader.Skip(length - 4u);
+						}
 					}
 					// read Unicode layer name
 					else if (key == util::Key<'l', 'u', 'n', 'i'>::VALUE)


### PR DESCRIPTION
PSD stores the pass-through property in the lsct section. After the 8 bits for the layer type, there may be another 8BIM magic number, followed by either a repeated blend mode or the special "pass" mode, which marks the group as being pass-through as opposed to isolated. Most drawing programs let you manipulate this property directly, since it's useful to have groups for organizational purposes, but not affecting the way the layers inside get rendered.

This patch adds reading of this property. I don't think the exporter supports layer groups, so there's no code for that added either.